### PR TITLE
feature: increase description size to 220

### DIFF
--- a/lib/middleman-meta-tags/helpers.rb
+++ b/lib/middleman-meta-tags/helpers.rb
@@ -230,7 +230,7 @@ module Middleman
 
         description = I18n.t(description[2..-1]) if description&.start_with?('t:')
 
-        truncate(strip_tags(description), length: 200)
+        truncate(strip_tags(description), length: 220)
       end
 
       def safe_title(title)


### PR DESCRIPTION
This PR increases the description to 220 (newer Google standard)

It's related to [Issue 17](https://github.com/tiste/middleman-meta-tags/issues/17)

**PS:** Are you planning in making PR's to @tiste's repository? Or could you at least activate Issues for your fork?